### PR TITLE
Respect users DNT settings

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
 
 <head>
     {% include base/head.html %}
-    <script async defer src="https://{{site.analytics-domain}}" data-website-id="{{site.analytics-id}}"></script>
+    <script async defer src="https://{{site.analytics-domain}}" data-website-id="{{site.analytics-id}}" data-do-not-track="true"></script>
 </head>
 
 <body class="flex flex-col antialiased cm-gray-1 min-h-screen">


### PR DESCRIPTION
Fixes #96

Due to a misconfiguration do not track was not always observed on firefox, this fixes that in my tests