### PR TITLE
Repoint documentation github link to main repository.

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -49,7 +49,7 @@ To contribute to the translation effort, navigate to the [InvenTree crowdin proj
 
 ### Documentation
 
-Documenting a large software project is a challenging and ongoing effort. If you are able to provide assistance in improving the documentation set, please consider doing so! Documentation contributions can be made on [GitHub](https://github.com/inventree/inventree-docs).
+Documenting a large software project is a challenging and ongoing effort. If you are able to provide assistance in improving the documentation set, please consider doing so! Documentation contributions can be made on [GitHub](https://github.com/inventree/InvenTree/tree/master/docs).
 
 If you see any sections of the documentation that require work (i.e. denoted with "TODO") - please consider providing assistance in these sections!
 


### PR DESCRIPTION
The inventree-docs repository [is now archived](https://github.com/inventree/inventree-docs) Apr 2023 and redirects to the main repository.

It looks like the right place for linking to would be [here](https://github.com/inventree/InvenTree/tree/master/docs), as the README looks basically the same and includes similar instructions as to creating a local development environment etc.