### PR TITLE
Add InvenTree Part Import to third party tools section

### DIFF
--- a/extend/integrate/index.md
+++ b/extend/integrate/index.md
@@ -9,6 +9,7 @@ Below is a non-exhaustive list of external tools that may be used in conjunction
 | Tool | Publisher | Description |
 | --- | --- | --- |
 | [Ki-n-Tree](https://github.com/sparkmicro/Ki-nTree) | [@sparkmicro](https://github.com/sparkmicro) | Tool for automating creation of InvenTree data from external systems such as DigiKey | 
+| [InvenTree Part Import](https://github.com/30350n/inventree_part_import) | [@30350n](https://github.com/30350n) | CLI to import parts from suppliers like DigiKey, LCSC, Mouser, etc. to InvenTree |
 | [PK2InvenTree](https://github.com/rgilham/PK2InvenTree) | [@rgilham](https://github.com/rgilham) | An open-source tool for migrating an existing [PartKeepr](https://github.com/partkeepr/PartKeepr) database to InvenTree |
 | [Digikey-Inventree-Integration](https://github.com/EUdds/Digikey-Inventree-Integration) | [@EUdds](https://github.com/EUdds) | A project that takes a digikey part number to creates a part in InvenTree. |
 


### PR DESCRIPTION
PR to add my [InvenTree Part Import](https://github.com/30350n/inventree_part_import) Tool in the Third Party Integrations section, as recommended by @SchrodingersGat [here](https://github.com/inventree/InvenTree/discussions/5904#discussioncomment-7570424) ^^