### PR TITLE
Make RSS / Atom feed actually show the post content, metadata etc.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -64,7 +64,6 @@ defaults:
 
 feed:
   path: /blog/feed.atom
-  excerpt_only: true
 
   collections:
     news:


### PR DESCRIPTION
Is there any specific reason why `excerpt_only` is set for the RSS feed? The way the feed looks right now for me in Thunderbird kind of defeats it's purpose imo:
![image](https://github.com/inventree/inventree-website/assets/34186858/b64bdd80-c114-4538-8632-180b9df8742b)
It only contains a title, small post description and author name, not even a link to the actual post.

According to the [jekyll-feed docs](https://github.com/jekyll/jekyll-feed/tree/master#excerpt-only-flag) this is probably due to said flag being set.