### PR TITLE
Add AppJail to Deploy section

### DIFF
--- a/deploy.md
+++ b/deploy.md
@@ -13,6 +13,10 @@ InvenTree supports a simple containerized installation via docker. An official [
 
 Refer to the [docker installation guide](https://docs.inventree.org/en/latest/start/docker/) for more information
 
+### AppJail
+
+InvenTree can be installed on FreeBSD using AppJail. An [AppJail Makejail](https://github.com/AppJail-makejails/inventree) is provided with regular updates.
+
 ### Manual Bare Metal Install
 
 A [bare metal installation guide](https://docs.inventree.org/en/latest/start/intro/) is provided for users who are looking for a low-level or custom installation. 


### PR DESCRIPTION
Hi,

I have created an AppJail Makejail (text file similar to a Dockerfile) to automate the installation and deployment of InvenTree on FreeBSD systems. This is how I use InvenTree on my server.